### PR TITLE
feat: add Haversine distance metric for geospatial data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ dist/
 benchmark.cpp
 data/
 .venv/
+venv/
 .env
 .env.*
 release.local.md

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Spheni is a C++ library with Python bindings to search for points in space that 
 ## Features
 
 1. Indexes: Flat, IVF
-2. Metrics: Cosine, L2
+2. Metrics: Cosine, L2, Haversine
 3. Storage: F32, INT8
 4. Ops: add, search, search_batch, train, save, load
 
@@ -58,6 +58,10 @@ It retrieves relevant lines based on meaning rather than exact keywords.
 It embeds text once and uses Spheni for fast, offline vector search.
 
 ![sphgrep](media/sphgrep.png)
+
+### Geospatial Search
+
+It can index locations (latitude, longitude) and find nearest neighbors using the Haversine formula, returning distances in kilometers. Perfect for "find stores near me" features.
 
 ## Try It Out
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ It embeds text once and uses Spheni for fast, offline vector search.
 
 ### Geospatial Search
 
-It can index locations (latitude, longitude) and find nearest neighbors using the Haversine formula, returning distances in kilometers. Perfect for "find stores near me" features.
+It can index locations (latitude, longitude) and find nearest neighbors using the Haversine formula, returning distances in kilometers.
+
+> [!IMPORTANT]
+> Haversine search currently requires **2D vectors** (latitude, longitude), must use **unnormalized F32 storage**, and is only supported on **Flat indexes** (no IVF or INT8 quantization).
+
+Perfect for "find stores near me" features.
 
 ## Try It Out
 

--- a/examples/geospatial.py
+++ b/examples/geospatial.py
@@ -5,7 +5,7 @@ def main():
     # 1. Create an index with Haversine metric
     #    Note: dimension MUST be 2 (latitude, longitude)
     #    Note: normalization MUST be False
-    spec = spheni.IndexSpec(2, spheni.Metric.Haversine, spheni.IndexKind.Flat)
+    spec = spheni.IndexSpec(2, spheni.Metric.Haversine, spheni.IndexKind.Flat, False)
     engine = spheni.Engine(spec)
 
     # 2. Add some locations (Latitude, Longitude)

--- a/examples/geospatial.py
+++ b/examples/geospatial.py
@@ -1,0 +1,40 @@
+import numpy as np
+import spheni
+
+def main():
+    # 1. Create an index with Haversine metric
+    #    Note: dimension MUST be 2 (latitude, longitude)
+    #    Note: normalization MUST be False
+    spec = spheni.IndexSpec(2, spheni.Metric.Haversine, spheni.IndexKind.Flat)
+    engine = spheni.Engine(spec)
+
+    # 2. Add some locations (Latitude, Longitude)
+    #    New York, London, Paris, Tokyo, Sydney
+    locations = np.array([
+        [40.7128, -74.0060],   # NY
+        [51.5074, -0.1278],    # London
+        [48.8566, 2.3522],     # Paris
+        [35.6762, 139.6503],   # Tokyo
+        [-33.8688, 151.2093]   # Sydney
+    ], dtype=np.float32)
+    
+    ids = np.array([0, 1, 2, 3, 4], dtype=np.longlong)
+    names = ["NY", "London", "Paris", "Tokyo", "Sydney"]
+    
+    engine.add(ids, locations)
+    print(f"Indexed {engine.size()} locations.")
+
+    # 3. Search for nearest neighbors to Berlin (52.5200, 13.4050)
+    query = np.array([52.5200, 13.4050], dtype=np.float32)
+    k = 3
+    results = engine.search(query, k)
+
+    print(f"\nFinding {k} nearest cities to Berlin:")
+    for hit in results:
+        # Haversine metric returns negative distance in kilometers
+        dist_km = -hit.score
+        name = names[hit.id]
+        print(f"- {name}: {dist_km:.2f} km")
+
+if __name__ == "__main__":
+    main()

--- a/include/spheni/spheni.h
+++ b/include/spheni/spheni.h
@@ -6,7 +6,7 @@
 
 namespace spheni {
 
-enum class Metric { Cosine, L2 };
+enum class Metric { Cosine, L2, Haversine };
 
 enum class IndexKind { Flat, IVF };
 

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -151,7 +151,7 @@ Engine Engine::load(const std::string &path) {
   if (dim <= 0) {
     throw std::runtime_error("Engine::load: invalid dimension.");
   }
-  if (metric_raw < 0 || metric_raw > 1) {
+  if (metric_raw < 0 || metric_raw > 2) {
     throw std::runtime_error("Engine::load: invalid metric.");
   }
   if (kind_raw < 0 || kind_raw > 1) {

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -151,7 +151,8 @@ Engine Engine::load(const std::string &path) {
   if (dim <= 0) {
     throw std::runtime_error("Engine::load: invalid dimension.");
   }
-  if (metric_raw < 0 || metric_raw > 2) {
+  if (metric_raw < 0 ||
+      metric_raw > static_cast<std::int32_t>(Metric::Haversine)) {
     throw std::runtime_error("Engine::load: invalid metric.");
   }
   if (kind_raw < 0 || kind_raw > 1) {

--- a/src/core/factory.cpp
+++ b/src/core/factory.cpp
@@ -20,6 +20,10 @@ std::unique_ptr<Index> make_index(const IndexSpec &spec) {
       throw std::invalid_argument(
           "Haversine metric does not support normalization");
     }
+    if (spec.storage == StorageType::INT8) {
+      throw std::invalid_argument(
+          "Haversine metric does not support INT8 storage");
+    }
   }
 
   switch (spec.kind) {

--- a/src/core/factory.cpp
+++ b/src/core/factory.cpp
@@ -8,6 +8,20 @@ std::unique_ptr<Index> make_index(const IndexSpec &spec) {
   // switch(spec.kind) { case IndexKind::Flat: continue; }
   // return std::make_unique<FlatIndex>(spec);
 
+  if (spec.metric == Metric::Haversine) {
+    if (spec.dim != 2) {
+      throw std::invalid_argument("Haversine metric requires dim=2");
+    }
+    if (spec.kind == IndexKind::IVF) {
+      throw std::invalid_argument(
+          "Haversine metric does not support IVF index");
+    }
+    if (spec.normalize) {
+      throw std::invalid_argument(
+          "Haversine metric does not support normalization");
+    }
+  }
+
   switch (spec.kind) {
   case IndexKind::Flat:
     return std::make_unique<FlatIndex>(spec);

--- a/src/indexes/flat/flat_index.cpp
+++ b/src/indexes/flat/flat_index.cpp
@@ -30,6 +30,11 @@ void FlatIndex::add(std::span<const long long> ids,
       }
     }
   } else if (spec_.storage == StorageType::INT8) {
+    if (spec_.metric == Metric::Haversine) {
+      throw std::runtime_error(
+          "FlatIndex::add: Haversine not supported with INT8.");
+    }
+
     std::vector<float> vec_copy;
     if (spec_.normalize && spec_.metric == Metric::Cosine) {
       vec_copy.assign(vectors.begin(), vectors.end());
@@ -43,10 +48,6 @@ void FlatIndex::add(std::span<const long long> ids,
         vec = vec_mut;
       }
       quantization::quantize_vector(vec, spec_.dim, vectors_i8_, scales_);
-    }
-    if (spec_.metric == Metric::Haversine) {
-      throw std::runtime_error(
-          "FlatIndex::add: Haversine not supported with INT8.");
     }
   } else {
     throw std::runtime_error("FlatIndex::add: unsupported storage type.");

--- a/src/indexes/flat/flat_index.cpp
+++ b/src/indexes/flat/flat_index.cpp
@@ -44,6 +44,10 @@ void FlatIndex::add(std::span<const long long> ids,
       }
       quantization::quantize_vector(vec, spec_.dim, vectors_i8_, scales_);
     }
+    if (spec_.metric == Metric::Haversine) {
+      throw std::runtime_error(
+          "FlatIndex::add: Haversine not supported with INT8.");
+    }
   } else {
     throw std::runtime_error("FlatIndex::add: unsupported storage type.");
   }
@@ -58,6 +62,9 @@ float FlatIndex::compute_score(const float *query, const float *db_vec) const {
 
   case Metric::L2:
     return -math::kernels::l2_squared(query, db_vec, spec_.dim);
+
+  case Metric::Haversine:
+    return -math::kernels::haversine(query, db_vec, spec_.dim);
   }
 
   return 0.0f;
@@ -84,6 +91,9 @@ float FlatIndex::compute_score_int8(const float *query,
     }
     return -sum;
   }
+  case Metric::Haversine:
+    throw std::runtime_error(
+        "FlatIndex::compute_score_int8: Haversine not supported with INT8.");
   }
   return 0.0f;
 }

--- a/src/math/kernels.cpp
+++ b/src/math/kernels.cpp
@@ -1,8 +1,43 @@
 #include "math/kernels.h"
 #include <algorithm>
 #include <cmath>
+#include <numbers>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 namespace spheni::math::kernels {
+float haversine(const float *a, const float *b, int d) {
+  // Input vectors are [lat, lon] in degrees.
+  (void)d; // unused, assumed to be 2 validated by caller
+
+  const float R = 6371.0f; // Earth radius in km
+  const float to_rad = static_cast<float>(M_PI / 180.0);
+
+  float lat1 = a[0] * to_rad;
+  float lon1 = a[1] * to_rad;
+  float lat2 = b[0] * to_rad;
+  float lon2 = b[1] * to_rad;
+
+  float dlat = lat2 - lat1;
+  float dlon = lon2 - lon1;
+
+  float a_hav = std::sin(dlat / 2) * std::sin(dlat / 2) +
+                std::cos(lat1) * std::cos(lat2) * std::sin(dlon / 2) *
+                    std::sin(dlon / 2);
+
+  // Clamp a_hav to [0, 1] to avoid NaNs from floating point errors
+  if (a_hav < 0.0f)
+    a_hav = 0.0f;
+  if (a_hav > 1.0f)
+    a_hav = 1.0f;
+
+  float c = 2 * std::atan2(std::sqrt(a_hav), std::sqrt(1 - a_hav));
+
+  return R * c;
+}
+
 float dot(const float *a, const float *b, int d) {
   float sum = 0.0f;
   for (int i = 0; i < d; ++i) {

--- a/src/math/kernels.h
+++ b/src/math/kernels.h
@@ -3,6 +3,7 @@
 namespace spheni::math::kernels {
 float dot(const float *a, const float *b, int d);
 float l2_squared(const float *a, const float *b, int d);
+float haversine(const float *a, const float *b, int d);
 void normalize(float *v, int d);
 float l2_norm(const float *v, int d);
 } // namespace spheni::math::kernels

--- a/src/python/bindings.cpp
+++ b/src/python/bindings.cpp
@@ -41,7 +41,8 @@ PYBIND11_MODULE(_core, m) {
 
   py::enum_<spheni::Metric>(m, "Metric")
       .value("Cosine", spheni::Metric::Cosine)
-      .value("L2", spheni::Metric::L2);
+      .value("L2", spheni::Metric::L2)
+      .value("Haversine", spheni::Metric::Haversine);
 
   py::enum_<spheni::IndexKind>(m, "IndexKind")
       .value("Flat", spheni::IndexKind::Flat)


### PR DESCRIPTION
## Overview
This PR adds support for the **Haversine Distance** metric, allowing `spheni` to be used for geospatial searches (e.g., finding nearest stores, friends, or landmarks) using latitude/longitude coordinates.

## Changes
- **Core Kernel**: Implemented `haversine()` in `src/math/kernels.cpp` using a robust formula (atan2) to handle edge cases like antipodal points.
- **API**: Added `Metric::Haversine` to the C++ core and Python bindings.
- **Validation**: Added checks to enforce `dim=2` and disable normalization/IVF for Haversine metric.
- **Index Support**: Updated `FlatIndex` to support the new metric (returns distance in km).
- **Documentation**: Updated `README.md` and added `examples/geospatial.py`.

## Usage
```python
import spheni
import numpy as np

# Create index for Lat/Lon (dim=2)
spec = spheni.IndexSpec(2, spheni.Metric.Haversine, spheni.IndexKind.Flat)
engine = spheni.Engine(spec)

# Add locations (e.g., [Latitude, Longitude])
locations = np.array([
    [40.7128, -74.0060],  # NY
    [51.5074, -0.1278]    # London
], dtype=np.float32)
engine.add(locations)

# Search
results = engine.search(locations[0], k=2)
# Score is negative distance in km
dist_km = -results[1].score 